### PR TITLE
Get Dublin Routing Key Boundaries

### DIFF
--- a/notebooks/download_data.py
+++ b/notebooks/download_data.py
@@ -17,7 +17,7 @@ download(
 )
 # %%
 download(
-    url="https://zenodo.org/record/4577018/files/dublin_boundary.geojson",
+    url="https://zenodo.org/record/4694645/files/dublin_boundary.geojson",
     filepath=data_dir / "dublin_boundary.geojson",
 )
 # %%
@@ -48,3 +48,9 @@ download_ber_public(
 )
 # %%
 download_dublin_valuation_office(data_dir=data_dir)
+# %%
+download(
+    url="https://www.autoaddress.ie/docs/default-source/default-document-library/routingkeys_mi_itm_2016_09_29.zip",
+    filepath=data_dir / "routingkeys_mi_itm_2016_09_29.zip",
+)
+# %%

--- a/notebooks/wrangle_boundaries.py
+++ b/notebooks/wrangle_boundaries.py
@@ -50,3 +50,23 @@ dublin_municipality_boundaries.to_file(
 )
 
 # %%
+ireland_routing_key_boundaries = gpd.read_file(
+    data_dir / "routingkeys_mi_itm_2016_09_29",
+).to_crs(epsg=2157)
+dublin_routing_key_boundaries = (
+    get_geometries_within(
+        ireland_routing_key_boundaries, dublin_boundary.to_crs(epsg=2157)
+    )
+    .assign(
+        CountyName=lambda gdf: gdf["Descriptor"]
+        .str.title()
+        .str.replace(r"^(?!Dublin \d+)(.*)$", "Co. Dublin", regex=True)
+    )
+    .pipe(get_geometries_within, dublin_municipality_boundaries.to_crs(epsg=2157))
+)
+dublin_routing_key_boundaries.to_file(
+    data_dir / "dublin_routing_boundaries.geojson",
+    driver="GeoJSON",
+)
+
+# %%


### PR DESCRIPTION
Can be used to link to all Postcode level data.
Specifically need it to check which postcodes
the Google Maps Geocoding API has returned for
each M&R building against its actual postcode