### PR TITLE
Calculate Valuaition Office Public Annual Heat demand

### DIFF
--- a/notebooks/wrangle_non_residential.py
+++ b/notebooks/wrangle_non_residential.py
@@ -36,3 +36,5 @@ vo_public = gpd.read_file(data_dir / "valuation_office_public.gpkg", driver="GPK
 vo_private = gpd.read_file(data_dir / "valuation_office_private.gpkg", driver="GPKG")
 anonymise_valuation_office_private(data_dir, vo_private, vo_public)
 # %%
+vo_public = gpd.read_file(data_dir / "valuation_office_public.gpkg", driver="GPKG")
+# %%


### PR DESCRIPTION
As there are no constraints on sharing the public version of the
Valuation Office data it has been adapted to estimate commercial
building heat demand in place of the private data for illustration
of the methodology on Google Colab - to be shared alongside the
heat demand estimate maps on the website