### PR TITLE
Geocode M&R using OSM localhost and Google Maps

### DIFF
--- a/notebooks/wrangle_boundaries.py
+++ b/notebooks/wrangle_boundaries.py
@@ -65,7 +65,7 @@ dublin_routing_key_boundaries = (
     .pipe(get_geometries_within, dublin_municipality_boundaries.to_crs(epsg=2157))
 )
 dublin_routing_key_boundaries.to_file(
-    data_dir / "dublin_routing_boundaries.geojson",
+    data_dir / "dublin_routing_key_boundaries.geojson",
     driver="GeoJSON",
 )
 

--- a/notebooks/wrangle_non_residential.py
+++ b/notebooks/wrangle_non_residential.py
@@ -11,30 +11,69 @@ from dublin_building_stock.non_residential import (
     create_valuation_office_public,
     create_valuation_office_private,
     anonymise_valuation_office_private,
+    create_m_and_r,
+    create_geocoded_m_and_r,
 )
 
 data_dir = Path("../data")
+
+
+# %%
+dublin_boundary = gpd.read_file(data_dir / "dublin_boundary.geojson", driver="GeoJSON")
+
+# %%
+dublin_routing_key_boundaries = gpd.read_file(
+    data_dir / "dublin_routing_key_boundaries.geojson", driver="GeoJSON"
+)
 
 # %%
 small_area_boundaries_2011 = gpd.read_file(
     data_dir / "Dublin_Census2011_Small_Areas_generalised20m"
 )
+
 # %%
 uses_linked_to_benchmarks = load_uses_benchmarks(data_dir)
+
 # %%
 benchmarks = load_benchmarks(data_dir)
+
 # %%
 create_valuation_office_public(
     data_dir, uses_linked_to_benchmarks, benchmarks, small_area_boundaries_2011
 )
+
 # %%
 create_valuation_office_private(
     data_dir, uses_linked_to_benchmarks, benchmarks, small_area_boundaries_2011
 )
+
 # %%
 vo_public = gpd.read_file(data_dir / "valuation_office_public.gpkg", driver="GPKG")
 vo_private = gpd.read_file(data_dir / "valuation_office_private.gpkg", driver="GPKG")
 anonymise_valuation_office_private(data_dir, vo_private, vo_public)
+
 # %%
-vo_public = gpd.read_file(data_dir / "valuation_office_public.gpkg", driver="GPKG")
+create_m_and_r(data_dir)
+
 # %%
+m_and_r = pd.read_csv(data_dir / "m_and_r.csv")
+create_geocoded_m_and_r(
+    data_dir, m_and_r, dublin_boundary, dublin_routing_key_boundaries
+)
+
+# %%
+m_and_r_locations = gpd.read_file(
+    data_dir / "M&R_clean_addresses_geocoded_by_google_maps.geojson", driver="GeoJSON"
+)
+m_and_r_geocoded = m_and_r_locations.merge(
+    m_and_r,
+    left_on="raw_address",
+    right_on="address",
+    how="right",
+)
+
+# %%
+m_and_r_geocoded.to_file(data_dir / "M&R_geocoded.geojson", driver="GeoJSON")
+
+# %%
+create_epa_industrial_sites(data_dir)


### PR DESCRIPTION
Parse the 4.6k M&R buildings to extract the road of each building using [pypostal](https://github.com/openvenues/pypostal), combine road and postcode into an address and query [Nominatim localhost (setup via docker)](https://github.com/mediagis/nominatim-docker)  to locate 2k/4.6k buildings.  Fill the rest with a representative point from it's postcode (this leaves ~600 Co. Dublin buildings which can't be located within any Dublin LA (as it crosses South Dublin, Fingal & Dun Laoghaire Rathdown).  

Initially normalised addresses via pypostal were queried via Google Maps and via Nominatim - the above method was used instead to get a better return with Nominatim which is free for bulk geocoding and has no data sharing constraints while Google Maps results aren't free and must be shared on a Google hosted map (such as My Maps)