### PR TITLE
Locate all EPS ETS Sites

### DIFF
--- a/dublin_building_stock/string_operations.py
+++ b/dublin_building_stock/string_operations.py
@@ -1,0 +1,65 @@
+import re
+from typing import List
+
+COUNTIES = [
+    "Antrim",
+    "Armagh",
+    "Carlow",
+    "Cavan",
+    "Clare",
+    "Cork",
+    "Donegal",
+    "Down",
+    "Dublin",
+    "Fermanagh",
+    "Galway",
+    "Kerry",
+    "Kildare",
+    "Kilkenny",
+    "Laois",
+    "Leitrim",
+    "Limerick",
+    "Londonderry",
+    "Longford",
+    "Louth",
+    "Mayo",
+    "Meath",
+    "Monaghan",
+    "Offaly",
+    "Roscommon",
+    "Sligo",
+    "Tipperary",
+    "Tyrone",
+    "Waterford",
+    "Westmeath",
+    "Wexford",
+    "Wicklow",
+]
+
+SITES = ["Drogheda"]
+
+
+def extract_ets_address(raw_text: str) -> str:
+    header_page_raw = re.findall(
+        r"(Permit Register Number:.+?)(?=\x0c)", raw_text[:2000], flags=re.DOTALL
+    )[0]
+    header_page_split = re.split(r"\n\n", header_page_raw)
+    locations = SITES + COUNTIES
+    address_raw = [
+        s for s in header_page_split if any([l.lower() in s.lower() for l in locations])
+    ]
+    assert len(address_raw) > 1, "Failed to extract both Operator & Location"
+
+    # Remove Organisation names such as 'Dublin Power Plant' that aren't either the
+    # Operator or Location
+    address = [
+        a for a in address_raw if a in sorted(address_raw, key=len, reverse=True)[:2]
+    ]
+    return address[-1]
+
+
+def extract_annual_ets_emissions(raw_text: str) -> float:
+    annual_emissions = re.findall(
+        r"Estimated Annual Emissions \(tonnes CO2\(e\)\)\n\n(\d+)", raw_text
+    )[0]
+    return float(annual_emissions)

--- a/tests/test_string_operations.py
+++ b/tests/test_string_operations.py
@@ -1,0 +1,44 @@
+import pytest
+
+from dublin_building_stock import string_operations
+
+
+@pytest.mark.parametrize(
+    "raw_text,expected_output",
+    [
+        (
+            "Headquarters, \nJohnstown Castle Estate,\nCounty Wexford, Ireland\n\nGREENHOUSE GAS EMISSIONS PERMIT\n\nPermit Register Number:\n\nIE-GHG182-10506-1\n\nOperator:\n\nAlexion Pharma International \nOperations Unlimited Company\nCollege Business & Technology Park,\nBlanchardstown Road North\nDublin 15\nD15 R925\n\nAlexion College Park\n\nCollege Business & Technology Park\nBlanchardstown Road North\nDublin 15\nIreland\n\nInstallation Name:\n\nAlexion College Park\n\nSite Name:\n\nLocation:\n\n\x0c\x0c",
+            "College Business & Technology Park\nBlanchardstown Road North\nDublin 15\nIreland",
+        ),
+        (
+            "Headquarters, \nJohnstown Castle Estate,\nCounty Wexford, Ireland\n\nGREENHOUSE GAS EMISSIONS PERMIT\n\nPermit Register Number:\n\nIE-GHG172-10469-4\n\nAmazon Data Services Ireland Limited\nOne Burlington Plaza\nBurlington Road\nDublin 4\nD04RH96\n\nOperator:\n\nSite Name:\n\nLocation:\n\nInstallation Name:\n\nDUB9\n\nADSIL DUB9\n\nGreenhills Road\nTallaght\nDublin 24\nIreland\n\n\x0c",
+            "Greenhills Road\nTallaght\nDublin 24\nIreland",
+        ),
+        (
+            "Headquarters, \nJohnstown Castle Estate,\nCounty Wexford, Ireland\n\nGREENHOUSE GAS EMISSIONS PERMIT\n\nPermit Register Number:\n\nIE-GHG091-10393-2\n\nOperator:\n\nTynagh Energy Limited\nThe Crescent Building\nNorthwood Park\nSantry\nDublin\nD09 X8W3\n\nTynagh 400MW CCPP\n\nDerryfrench\nTynagh\nLoughrea\nGalway\n\nInstallation Name:\n\nTynagh 400MW CCPP\n\nSite Name:\n\nLocation:\n\n\x0c",
+            "Derryfrench\nTynagh\nLoughrea\nGalway",
+        ),
+        (
+            "Headquarters, \nJohnstown Castle Estate,\nCounty Wexford, Ireland\n\nGREENHOUSE GAS EMISSIONS PERMIT\n\nPermit Register Number:\n\nIE-GHG200-10527-1\n\nOperator:\n\nAmazon Data Services Ireland Limited\nOne Burlington Plaza\nBurlington Road\nDublin 4\nDublin\nD04RH96\n\nInstallation Name:\n\nData Processing Centre - DUB 62\n\nSite Name:\n\nLocation:\n\nData Processing Centre - DUB 62\n\nDrogheda IDA Business and Technology \nPark\nDonore Road\nDrogheda\n\n\x0cMeath\nIreland\n\n\x0c",
+            "Drogheda IDA Business and Technology \nPark\nDonore Road\nDrogheda",
+        ),
+        (
+            "Headquarters, \nJohnstown Castle Estate,\nCounty Wexford, Ireland\n\nGREENHOUSE GAS EMISSIONS PERMIT\n\nPermit Register Number:\n\nIE-GHG016-10346-4\n\nOperator:\n\nSynergen Power Limited\nESB Dublin Bay\nPigeon House Road\nRingsend\nDublin\nD04 Y5N2\n\nDublin Bay Power Plant\n\nPigeon House Road\nRingsend\nDublin 4\nIreland\n\nInstallation Name:\n\nDublin Bay Power Plant\n\nSite Name:\n\nLocation:\n\n\x0c",
+            "Pigeon House Road\nRingsend\nDublin 4\nIreland",
+        ),
+        (
+            "Headquarters, \nJohnstown Castle Estate,\nCounty Wexford, Ireland\n\nGREENHOUSE GAS EMISSIONS PERMIT\n\nPermit Register Number:\n\nIE-GHG190-10516-1\n\nOperator:\n\nDigital Netherlands VIII B.V.\nStratus House, Unit 1\n1st  Floor, College Business & \nTechnology Park\nBlanchardstown\nDUBLIN 15\n\nInstallation Name:\n\nDUB14 Profile Park\n\nSite Name:\n\nLocation:\n\nDUB14 Profile Park\n\nGrange Castle, Nangor Road\nDublin 22\nIreland\n\n\x0c",
+            "Grange Castle, Nangor Road\nDublin 22\nIreland",
+        ),
+    ],
+)
+def test_extract_ets_address(raw_text, expected_output) -> None:
+    output = string_operations.extract_ets_address(raw_text)
+    assert output == expected_output
+
+
+def test_extract_annual_ets_emissions() -> None:
+    raw_text = "Estimated Annual Emissions (tonnes CO2(e))\n\n1450000"
+    expected_output = float(1450000)
+    output = string_operations.extract_annual_ets_emissions(raw_text)
+    assert output == expected_output


### PR DESCRIPTION
Extract the site Address (not Operator) from each pdf, manually
locate each site, identify its use and link to its corresponding
Valuation Office ID